### PR TITLE
Check for bundled libgd

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -95,6 +95,15 @@ if test $PHP_ZBARCODE != "no"; then
       AC_MSG_ERROR(not found. Run with --disable-zbarcode-gd to disable this feature)
     fi
 
+    AC_MSG_CHECKING(bundled libgd)
+
+    PHP_GD_BUNDLED_LIBGD_CHECK_HEADER="`$PHP_CONFIG --include-dir`/ext/gd/libgd/gd.h"
+
+    if test -r $PHP_GD_BUNDLED_LIBGD_CHECK_HEADER; then
+      AC_MSG_RESULT(found.)
+      AC_DEFINE(HAVE_GD_BUNDLED,1,[ ])
+    fi
+
     PHP_ADD_EXTENSION_DEP(zbarcode, gd)
     AC_DEFINE(HAVE_ZBARCODE_GD,1,[ ])
   fi  


### PR DESCRIPTION
Required to build correctly against shared gd.so with bundled libgd, because `gdImageBoundSafe()` is a [function](https://github.com/libgd/libgd/blob/08ae745426579be883d7f8aeabcc592b24de0597/src/gd.c#L1860) in upstream but a [macro](https://github.com/php/php-src/blob/c8ba185cf92c4138704a3c3b663a7a83d96e897f/ext/gd/libgd/gd.h#L916) in bundled.