### PR TITLE
fix_zbar_version

### DIFF
--- a/zbarcode.c
+++ b/zbarcode.c
@@ -979,12 +979,12 @@ PHP_MSHUTDOWN_FUNCTION(zbarcode)
 */
 PHP_MINFO_FUNCTION(zbarcode)
 {
-	unsigned int major = 0, minor = 0;
+	unsigned int major = 0, minor = 0, patch;
 	char *zbar_ver = NULL;
 	unsigned long magick_version;
 
-	zbar_version(&major, &minor);
-	spprintf(&zbar_ver, 24, "%d.%d", major, minor);
+	zbar_version(&major, &minor, &patch);
+	spprintf(&zbar_ver, 24, "%d.%d.d%", major, minor, patch);
 
 	php_info_print_table_start();
 	php_info_print_table_row(2, "zbarcode module",			"enabled");


### PR DESCRIPTION
`zbarcode.c:986:2: error: too few arguments to function ‘zbar_version’
  zbar_version(&major, &minor);
  ^~~~~~~~~~~~`